### PR TITLE
feat(renaming): add move to parent directory functionality

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -5,6 +5,7 @@ pub enum Operation {
     None,
     Delete,
     Rename,
+    MoveToParent, // 当目录名被完全清理时，将内容移动到父目录
 }
 
 #[derive(Debug)]

--- a/src/p2tree.rs
+++ b/src/p2tree.rs
@@ -92,6 +92,10 @@ pub fn path_list_to_tree(
                 let node_data = _node.data();
                 *node_data = format!("{} {} => {}", node_data, SYMBOL_RENAME.yellow(), _pattern);
             }
+            Operation::MoveToParent => {
+                let node_data = _node.data();
+                *node_data = format!("{} {} ↗ 移动内容到父目录", node_data, SYMBOL_RENAME.green());
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
当整个目录名符合清理规则被清理时，将其下内容移动到上一层。（因为系统不允许空的目录名）